### PR TITLE
(fix) Use GITHUB_OUTPUT instead of GITHUB_ENV

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ status="$?"
 
 # Sets the output variable for GitHub Action API:
 # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-echo "output=$output" >> "$GITHUB_ENV"
+echo "output=$output" >> "$GITHUB_OUTPUT"
 echo '================================='
 echo
 


### PR DESCRIPTION
Previous commit ( https://github.com/sobolevn/misspell-fixer-action/pull/12 ) switched from using `set-output`, which is deprecated, but I mistakenly switched to writing to `GITHUB_ENV`, which sets environment variables, rather than `GITHUB_OUTPUT`, to set outputs for Github Actions jobs.

Thanks to @ouuan for pointing this out ( https://github.com/sobolevn/misspell-fixer-action/pull/12#issuecomment-1418592547 ).